### PR TITLE
Move broccoli related modules from devDeps to deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # ember-cli-polymer-toolchain
 Ember CLI Toolchain for Polymer 1.X
 
+#Installation
+
+```
+ember install ember-cli-polymer-toolchain
+```
+
+Then in the root for your project create an ```elements``` folder. All html imports
+should be done in ```elements/index.html```. Example file:
+
+```
+<link rel="import" href="../bower_components/paper-drawer-panel/paper-drawer-panel.html">
+<link rel="import" href="../bower_components/paper-header-panel/paper-header-panel.html">
+<link rel="import" href="../bower_components/paper-toolbar/paper-toolbar.html">
+```
+
 ##Installation locally
 
 In this project's directory make available via npm:

--- a/index.js
+++ b/index.js
@@ -9,11 +9,7 @@ var htmlAutoprefixer = require('html-autoprefixer');
 
 module.exports = {
   name: 'ember-cli-polymer-toolchain',
-
-  isDevelopingAddon: function() {
-    return true;
-  },
-
+  
   contentFor: function(type) {
     if (type === 'head-footer') {
       return [

--- a/package.json
+++ b/package.json
@@ -17,11 +17,15 @@
   },
   "author": "",
   "license": "MIT",
+  "dependencies": {
+    "ember-cli-babel": "^5.0.0",
+    "html-autoprefixer": "^0.3.7",
+    "broccoli-vulcanize": "pk4media/broccoli-vulcanize",
+    "broccoli-funnel": "^0.2.3",
+    "broccoli-merge-trees": "^0.2.2"
+  },
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "broccoli-funnel": "^0.2.3",
-    "broccoli-merge-trees": "^0.2.2",
-    "broccoli-vulcanize": "pk4media/broccoli-vulcanize",
     "ember-cli": "0.2.3",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
@@ -39,10 +43,6 @@
   "keywords": [
     "ember-addon"
   ],
-  "dependencies": {
-    "ember-cli-babel": "^5.0.0",
-    "html-autoprefixer": "^0.3.7"
-  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }


### PR DESCRIPTION
The broccoli helper libraries need to be included as dependencies, so that npm includes them when installing in client projects.
